### PR TITLE
Switch to in-memory to_stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ glvis/nbextension
 js/node_modules
 *.ipynb
 *.saved
+*.mesh
+__pycache__
+*.egg-info
+js/dist
+build

--- a/glvis/widget.py
+++ b/glvis/widget.py
@@ -63,9 +63,11 @@ class glvis(widgets.DOMWidget):
             raise TypeError
         offset = stream.find("\n")
         self._data_type = stream[0:offset]
-        self._data_str = stream[offset + 1:]
+        self._data_str = stream[offset + 1 :]
 
-    def __init__(self, data: Stream, width: int = 640, height: int = 480, *args, **kwargs):
+    def __init__(
+        self, data: Stream, width: int = 640, height: int = 480, *args, **kwargs
+    ):
         widgets.DOMWidget.__init__(self, *args, **kwargs)
         self.set_size(width, height)
         self._sync(data, is_new=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # They are required for binder.
 numpy
 scipy
-mfem>=4.2.0.7
+mfem>=4.2.0.8


### PR DESCRIPTION
* Use PyMFEM's new `WriteToStream()` instead of a temp file when `to_stream`-ing `Mesh` and `GridFunction`
* Add typing info for more functions in _widget.py_
* Update _.gitignore_


Resolves https://github.com/GLVis/pyglvis/issues/4