### PR TITLE
Screenshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,27 @@ jupyter labextension install glvis-jupyter
 
 ## Development
 
-Development installation requires `npm`, after installing:
+Development installation requires `npm`.
+
+If you want to test a new version of `glvis`:
+
+1. Bump the version in _pyglvis/js/package.json_ and _glvis-js/package.json_
+2. `npm install path/to/glvis-js`
+
+
+Each time you update stuff in _pyglvis/js/src_:
+
+1. `npm install`
+2. `npx webpack`
+
+
+Once:
 
 ```
 git clone https://github.com/glvis/pyglvis.git
 cd pyglvis
 pip install -e .
 ```
-
 
 ### Developing in Jupyter Notebook
 

--- a/glvis/widget.py
+++ b/glvis/widget.py
@@ -85,6 +85,9 @@ class glvis(widgets.DOMWidget):
     def render(self):
         ipydisplay(self)
 
+    def screenshot(self, name):
+        self.send({"type": "screenshot", "name": name})
+
     def serialize(self):
         """Return dict that can be used to construct a copy of this instance
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "glvis-jupyter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "glvis-jupyter",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^4.0.0",
-        "glvis": "^0.1.1",
+        "glvis": "^0.2.1",
         "lodash": "^4.17.19"
       },
       "devDependencies": {
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/glvis": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/glvis/-/glvis-0.1.1.tgz",
-      "integrity": "sha512-ovTs3EabnEsO0SB8P0HbqnpB8DKcNzQz8ELO6B/vJcwQaDr53Ng3zLk2t5LF4jFZz/7n8w9Fce15HUyInKn67A=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/glvis/-/glvis-0.2.1.tgz",
+      "integrity": "sha512-oj/hCvebJpN7Ln4877MmmG5hlh9W/VL+1fv4M0K/guoVDevev5/sAS7dXL9pnEEdVWEig7YHHmLOaC361xm0hA=="
     },
     "node_modules/got": {
       "version": "9.6.0",
@@ -11754,9 +11754,9 @@
       }
     },
     "glvis": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/glvis/-/glvis-0.1.1.tgz",
-      "integrity": "sha512-ovTs3EabnEsO0SB8P0HbqnpB8DKcNzQz8ELO6B/vJcwQaDr53Ng3zLk2t5LF4jFZz/7n8w9Fce15HUyInKn67A=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/glvis/-/glvis-0.2.1.tgz",
+      "integrity": "sha512-oj/hCvebJpN7Ln4877MmmG5hlh9W/VL+1fv4M0K/guoVDevev5/sAS7dXL9pnEEdVWEig7YHHmLOaC361xm0hA=="
     },
     "got": {
       "version": "9.6.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glvis-jupyter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Jupyter Widget using glvis-js",
   "author": "",
   "license": "BSD-3-Clause",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^4.0.0",
-    "glvis": "^0.1.1",
+    "glvis": "^0.2.1",
     "lodash": "^4.17.19"
   },
   "jupyterlab": {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -27,7 +27,7 @@ var GLVisModel = widgets.DOMWidgetModel.extend({
 });
 
 var GLVisView = widgets.DOMWidgetView.extend({
-  render: function () {
+  render: function() {
     this.div = document.createElement("div");
     this.div.setAttribute("id", glvis.rand_id());
     this.div.setAttribute("tabindex", "0");
@@ -36,19 +36,26 @@ var GLVisView = widgets.DOMWidgetView.extend({
     this.height = this.model.get("height");
 
     this.glv = new glvis.State(this.div, this.width, this.height);
-    this.model.on("change:data_str", this.visualize, this);
-    this.model.on("change:height", this.resize, this);
-    this.model.on("change:width", this.resize, this);
-    this.visualize();
+    this.model.on("change:data_str", this.plot, this);
+    this.model.on("change:height", this.set_size, this);
+    this.model.on("change:width", this.set_size, this);
+    this.model.on('msg:custom', this.handle_message, this);
+    this.plot();
   },
 
-  resize: function () {
+  handle_message: function(msg, buffers) {
+    if (msg.type === "screenshot") {
+      this.glv.saveScreenshot(msg.name);
+    }
+  },
+
+  set_size: function() {
     const width = this.model.get("width");
     const height = this.model.get("height");
     this.glv.setSize(width, height);
   },
 
-  visualize: function () {
+  plot: function() {
     const type = this.model.get("data_type");
     const data = this.model.get("data_str");
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -27,7 +27,7 @@ var GLVisModel = widgets.DOMWidgetModel.extend({
 });
 
 var GLVisView = widgets.DOMWidgetView.extend({
-  render: function() {
+  render: function () {
     this.div = document.createElement("div");
     this.div.setAttribute("id", glvis.rand_id());
     this.div.setAttribute("tabindex", "0");
@@ -39,23 +39,30 @@ var GLVisView = widgets.DOMWidgetView.extend({
     this.model.on("change:data_str", this.plot, this);
     this.model.on("change:height", this.set_size, this);
     this.model.on("change:width", this.set_size, this);
-    this.model.on('msg:custom', this.handle_message, this);
+    this.model.on("msg:custom", this.handle_message, this);
     this.plot();
   },
 
-  handle_message: function(msg, buffers) {
+  handle_message: function (msg, buffers) {
     if (msg.type === "screenshot") {
-      this.glv.saveScreenshot(msg.name);
+      if (msg.use_web) {
+        this.glv.saveScreenshot(msg.name);
+      } else {
+        let that = this;
+        this.glv.getPNGAsB64().then((v) => {
+          that.send({ type: "screenshot", name: msg.name, b64: v });
+        });
+      }
     }
   },
 
-  set_size: function() {
+  set_size: function () {
     const width = this.model.get("width");
     const height = this.model.get("height");
     this.glv.setSize(width, height);
   },
 
-  plot: function() {
+  plot: function () {
     const type = this.model.get("data_type");
     const data = this.model.get("data_str");
 


### PR DESCRIPTION
Note: this requires a yet-to-be released version of `glvis` from npm that I'm working with locally. We can update `glvis` once https://github.com/GLVis/glvis-js/pull/11 & https://github.com/GLVis/glvis/pull/195 are merged.

Right now the screenshot is triggered from JavaScript so the usual browser download rules apply. Here is what things look like:

TODO: 
- [x] update `glvis` dependency

<img width="889" alt="Screen Shot 2021-08-25 at 3 31 26 PM" src="https://user-images.githubusercontent.com/7017223/130872961-12687759-0d48-4593-bff5-37be6f94b921.png">

And the actual output: ![star(4)](https://user-images.githubusercontent.com/7017223/130873004-b6f75bb5-1573-4152-b4e4-7df279eef5db.png)

Another option would be to get the screen state back to Python and write the file from there. We wouldn't be "downloading" it in the same way.

I think I like the Python approach more because there wouldn't be a download dialog (then again Chrome just downloads the files without a dialog) but I need to try a few more things to get it working.

Is there anything else you were hoping for @rw-anderson, @tzanio , @kmittal2? (I saw you all participated in some way or another on https://github.com/GLVis/pyglvis/issues/5)

addresses: https://github.com/GLVis/pyglvis/issues/5