### PR TITLE
Fix colab numpy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ graph TD;
     A --> C[glvis];
     C --> D[glvis-js];
     Ext1[emscripten] --> D;
-    D-.-E["glvis-js\n(npm/esm mirror)"]
+    D-.-E["glvis-js (esm)"]
     B & E --> G[pyglvis];
     Ext2[jupyter] --> G;
 ```
 
-`pyglvis` is most directly depednent on `PyMFEM` and `glvis-js`. [PyMFEM](https://github.com/mfem/pymfem) is a Python wrapper of the finite element library, `MFEM`, while `glvis-js` is a JavaScript/WebAssembly port of `glvis`.
+`pyglvis` is most directly dependent on `PyMFEM` and `glvis-js`. [PyMFEM](https://github.com/mfem/pymfem) is a Python wrapper of the finite element library, `MFEM`, while `glvis-js` is a JavaScript/WebAssembly port of `glvis`.
 
 `glvis-js` is hosted on [github](https://github.com/glvis/glvis-js) and mirrored on [npm](https://www.npmjs.com/package/glvis). [esm.sh](https://esm.sh/glvis) allows `pyglvis` to pull the latest version of `glvis-js` directly from npm. This can be seen in the first line of [glvis/widget.js](glvis/widget.js):
 

--- a/examples/ex1.ipynb
+++ b/examples/ex1.ipynb
@@ -14,7 +14,8 @@
    "outputs": [],
    "source": [
     "# Pip installs pyglvis (and pymfem) if in a colab notebook. Can comment out if not required\n",
-    "!pip install --quiet glvis\n",
+    "# PyMFEM requires numpy < 2.0.0\n",
+    "!pip install --quiet numpy==1.26.4 glvis\n",
     "from glvis import glvis, GlvisData"
    ]
   },

--- a/examples/ex9.ipynb
+++ b/examples/ex9.ipynb
@@ -37,7 +37,8 @@
    "outputs": [],
    "source": [
     "# Pip installs pyglvis (and pymfem) if in a colab notebook. Can comment out if not required\n",
-    "!pip install --quiet glvis\n",
+    "# PyMFEM requires numpy < 2.0.0\n",
+    "!pip install --quiet numpy==1.26.4 glvis\n",
     "from __future__ import print_function\n",
     "from os.path import expanduser, join\n",
     "import time\n",

--- a/examples/plot.ipynb
+++ b/examples/plot.ipynb
@@ -7,7 +7,8 @@
    "outputs": [],
    "source": [
     "# Pip installs pyglvis if in a colab notebook. Can comment out if not required\n",
-    "!pip install --quiet glvis\n",
+    "# PyMFEM requires numpy < 2.0.0\n",
+    "!pip install --quiet numpy==1.26.4 glvis\n",
     "import mfem.ser as mfem\n",
     "import ipywidgets as widgets\n",
     "from glvis import glvis\n",


### PR DESCRIPTION
Colab notebooks have some default libraries that are automatically updated. It looks like they recently upgraded `numpy` to `>=2.0.0`, which `PyMFEM` (and other libraries) aren't supporting yet. `PyMFEM` specifies it requires `numpy < 2.0.0` but it looks like the notebook isn't respecting that. This PR downgrades `numpy` on the Colab notebooks